### PR TITLE
Adding Scale from Metadata to Layer

### DIFF
--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -247,7 +247,7 @@ def bioio_napari_reader(path: str) -> list[Any]:
     # If only one scene, use the original naming
     if len(available_scenes) == 1:
         data = img.data
-        meta = {"name": base_name, "metadata": img.metadata, "scales": _get_scale(img.metadata)}
+        meta = {"name": base_name, "metadata": img.metadata, "scale": _get_scale(img.metadata)}
         layers.append((data, meta, "image"))
         
     else:
@@ -269,7 +269,7 @@ def bioio_napari_reader(path: str) -> list[Any]:
                         "scene_index": scene_idx,
                         "scene_name": scene_name,
                         "total_scenes": len(available_scenes),
-                        "scales": _get_scale(img.metadata)
+                        "scale": _get_scale(img.metadata)
                         
                     },
                 },

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -139,6 +139,13 @@ def bioio_napari_reader(path: str) -> list[Any]:
     Scene name: Background
     """
 
+    def _get_scale(metadata):
+        scale = None
+        if metadata.images[0].pixels:
+            px_data = img.metadata.images[0].pixels
+            scale = [px_data.physical_size_z, px_data.physical_size_y, px_data.physical_size_x]
+        return scale
+        
     def _extract_scene_name(img, scene_id: str, scene_idx: int) -> str:
         """
         Extract scene name from metadata, fallback to numbered name.
@@ -240,8 +247,9 @@ def bioio_napari_reader(path: str) -> list[Any]:
     # If only one scene, use the original naming
     if len(available_scenes) == 1:
         data = img.data
-        meta = {"name": base_name, "metadata": img.metadata}
+        meta = {"name": base_name, "metadata": img.metadata, "scales": _get_scale(img.metadata)}
         layers.append((data, meta, "image"))
+        
     else:
         # Multiple scenes: create a layer for each scene
         for scene_idx, scene_id in enumerate(available_scenes):
@@ -261,9 +269,12 @@ def bioio_napari_reader(path: str) -> list[Any]:
                         "scene_index": scene_idx,
                         "scene_name": scene_name,
                         "total_scenes": len(available_scenes),
+                        "scales": _get_scale(img.metadata)
+                        
                     },
                 },
             }
+
             layers.append((data, meta, "image"))
 
     return layers

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -140,10 +140,17 @@ def bioio_napari_reader(path: str) -> list[Any]:
     """
 
     def _get_scale(metadata):
-        scale = None
+        scale = []
         if metadata.images[0].pixels:
             px_data = img.metadata.images[0].pixels
-            scale = [px_data.physical_size_z, px_data.physical_size_y, px_data.physical_size_x]
+            if px_data.physical_size_z:
+                scale.append(px_data.physical_size_z)
+            if px_data.physical_size_y:
+                scale.append(px_data.physical_size_y)
+            if px_data.physical_size_x:
+                scale.append(px_data.physical_size_x)
+        if len(scale) == 0:
+            scale = None
         return scale
         
     def _extract_scene_name(img, scene_id: str, scene_idx: int) -> str:

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -322,7 +322,6 @@ def bioio_napari_reader(path: str) -> list[Any]:
                         "scene_name": scene_name,
                         "total_scenes": len(available_scenes),
                         "scale": _get_scale(img.metadata)
-                        
                     },
                 },
             }

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -143,7 +143,13 @@ def bioio_napari_reader(path: str) -> list[Any]:
         """
         Extract physical pixel sizes from metadata, if available.
 
-        Returns a list [z, y, x] or None if the scale cannot be determined.
+        Returns
+        -------
+        list[float] or None
+            A list of available physical pixel sizes in ``[z, y, x]`` order.
+            Only axes with a defined physical size are included, so the list
+            may have length 1–3 (e.g. ``[y, x]`` or ``[x]``). Returns ``None``
+            if no physical pixel sizes can be determined.
         """
         scale = []
         try:

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -174,7 +174,6 @@ def bioio_napari_reader(path: str) -> list[Any]:
         if not scale:
             return None
         return scale
-        
     def _extract_scene_name(img, scene_id: str, scene_idx: int) -> str:
         """
         Extract scene name from metadata, fallback to numbered name.

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -270,7 +270,31 @@ def bioio_napari_reader(path: str) -> list[Any]:
     # If only one scene, use the original naming
     if len(available_scenes) == 1:
         data = img.data
-        meta = {"name": base_name, "metadata": img.metadata, "scale": _get_scale(img.metadata)}
+        # Construct a full-length scale vector for napari:
+        # pad non-spatial axes (e.g., T, C) with 1.0 and apply spatial scales to the last axes.
+        scale = _get_scale(img.metadata)
+        try:
+            # Treat scale as a sequence; napari expects len(scale) == data.ndim
+            scale_len = len(scale)  # type: ignore[arg-type]
+        except TypeError:
+            # If scale is a scalar, leave it as-is
+            full_scale = scale
+        else:
+            if scale_len == data.ndim:
+                full_scale = scale
+            elif scale_len < data.ndim:
+                # Assume spatial dimensions are the last axes
+                pad_len = data.ndim - scale_len
+                full_scale = [1.0] * pad_len + list(scale)
+            else:
+                # More scales than dimensions: truncate to match data.ndim
+                full_scale = list(scale)[-data.ndim :]
+
+        meta = {
+            "name": base_name,
+            "metadata": img.metadata,
+            "scale": full_scale,
+        }
         layers.append((data, meta, "image"))
         
     else:

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -140,17 +140,33 @@ def bioio_napari_reader(path: str) -> list[Any]:
     """
 
     def _get_scale(metadata):
+        """
+        Extract physical pixel sizes from metadata, if available.
+
+        Returns a list [z, y, x] or None if the scale cannot be determined.
+        """
         scale = []
-        if metadata.images[0].pixels:
-            px_data = metadata.images[0].pixels
-            if px_data.physical_size_z:
+        try:
+            images = getattr(metadata, "images", None)
+            if not images:
+                return None
+
+            first_image = images[0]
+            px_data = getattr(first_image, "pixels", None)
+            if px_data is None:
+                return None
+
+            if getattr(px_data, "physical_size_z", None) is not None:
                 scale.append(px_data.physical_size_z)
-            if px_data.physical_size_y:
+            if getattr(px_data, "physical_size_y", None) is not None:
                 scale.append(px_data.physical_size_y)
-            if px_data.physical_size_x:
+            if getattr(px_data, "physical_size_x", None) is not None:
                 scale.append(px_data.physical_size_x)
-        if len(scale) == 0:
-            scale = None
+        except (AttributeError, IndexError, TypeError):
+            return None
+
+        if not scale:
+            return None
         return scale
         
     def _extract_scene_name(img, scene_id: str, scene_idx: int) -> str:

--- a/src/napari_bioio_reader/_reader.py
+++ b/src/napari_bioio_reader/_reader.py
@@ -142,7 +142,7 @@ def bioio_napari_reader(path: str) -> list[Any]:
     def _get_scale(metadata):
         scale = []
         if metadata.images[0].pixels:
-            px_data = img.metadata.images[0].pixels
+            px_data = metadata.images[0].pixels
             if px_data.physical_size_z:
                 scale.append(px_data.physical_size_z)
             if px_data.physical_size_y:


### PR DESCRIPTION
Added ability to obtain scaling info for zyx coords, and append them to a dict key called "scale" in the meta["metadata"] dictionary. New function: _get_scale.